### PR TITLE
Fix AzuraCast issue 2553

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -80,7 +80,7 @@ install() {
                 exit 1
             fi
 
-            COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$" | tail -n 1`
+            COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "v?[0-9]+\.[0-9][0-9]+\.[0-9]+$" | sort -t'/' -n | tail -n 1`
 
             if [[ $EUID -ne 0 ]]; then
                 if [[ ! $(which sudo) ]]; then

--- a/docker.sh
+++ b/docker.sh
@@ -80,7 +80,7 @@ install() {
                 exit 1
             fi
 
-            COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "v?[0-9]+\.[0-9][0-9]+\.[0-9]+$" | sort -t'/' -n | tail -n 1`
+            COMPOSE_VERSION=1.25.3
 
             if [[ $EUID -ne 0 ]]; then
                 if [[ ! $(which sudo) ]]; then


### PR DESCRIPTION
Modify the regex for COMPOSE_VERSION to match wrongly tagged releases and add a numerical sort to ensure we pull the newest version.

Closes https://github.com/AzuraCast/AzuraCast/issues/2553