### PR TITLE
missing starting quote in relay section

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -36,7 +36,7 @@ services:
     restart : always
 
   relay:
-    image: azuracast/azurarelay:${AZURARELAY_VERSION:-latest}"
+    image: "azuracast/azurarelay:${AZURARELAY_VERSION:-latest}"
     env_file: azurarelay.env
     environment:
       VIRTUAL_HOST : ${LETSENCRYPT_HOST:-azurarelay.local}


### PR DESCRIPTION
This caused an install issue for me - i narrowed it down to the missing starting quotation mark here.

![image](https://user-images.githubusercontent.com/23050115/111079214-e68dc400-84f0-11eb-9b3a-e5ecaae0c495.png)



![image](https://user-images.githubusercontent.com/23050115/111079225-f4434980-84f0-11eb-9866-fb5c5709d3a1.png)
