### PR TITLE
Installer fixes and improvements

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -1,5 +1,6 @@
 services:
   relay:
+    container_name: azurarelay_relay
     image: "ghcr.io/azuracast/relay:${AZURARELAY_VERSION:-latest}"
     env_file: azurarelay.env
     environment:

--- a/docker.sh
+++ b/docker.sh
@@ -342,7 +342,7 @@ install() {
   docker-compose pull
   docker-compose up -d
   docker-compose run --rm --user="azurarelay" relay cli app:setup
-  docker cp azurarelay_relay_1:/var/azurarelay/www_tmp/azurarelay.env ./azurarelay.env
+  docker cp azurarelay_relay:/var/azurarelay/www_tmp/azurarelay.env ./azurarelay.env
   docker-compose down -v
 
   docker-compose up -d

--- a/www/src/Console/Command/SetupCommand.php
+++ b/www/src/Console/Command/SetupCommand.php
@@ -114,9 +114,26 @@ class SetupCommand extends Command
         // Relay Base URL
         //
 
+        $io->writeln('Provide the base URL of that installation (including "http://" or "https://") to continue.');
+
         $publicIp = @file_get_contents('http://ipecho.net/plain');
 
         $question = new Question\Question('Relay Base URL', getenv('AZURARELAY_BASE_URL') ?? $publicIp);
+        $question->setMaxAttempts(10);
+        $question->setValidator(function ($value) {
+            $relayBaseUri = new Uri($value);
+            if (!in_array($relayBaseUri->getScheme(), ['http', 'https'])) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'The entered URL "%s" must include "http://" or "https://"',
+                        $value,
+                    )
+                );
+            }
+
+            return $value;
+        });
+
         $relayBaseUrl = $io->askQuestion($question);
 
         //


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
This PR fixes an issue with the copying of `azurarelay.env` file from the container after running the setup.

In my tests the container name for an installation at the default directory `/var/azurarelay` was `azurarelay-relay-1` but the `docker cp` command was using `azurarelay_relay_1` which resulted in an empty `azurarelay.env` file on the host.

I have also modified the setup command to explicitly require a url using the `http` or `https` scheme for the `$relayBaseUrl` since this is what we need this value to be set to.
