### PR TITLE
Add LE .well-known directory to nginx config

### DIFF
--- a/build/nginx/azurarelay.conf.tmpl
+++ b/build/nginx/azurarelay.conf.tmpl
@@ -53,6 +53,12 @@ server {
         internal;
     }
 
+    # LetsEncrypt handling
+    location /.well-known/acme-challenge/ {
+        root /usr/share/nginx/html;
+        try_files $uri =404;
+    }
+
     # Return 404 for all other php files not matching the front controller
     location ~ \.php$ {
         return 404;


### PR DESCRIPTION
**Fixes issue:**
#38

**Proposed changes:**
This PR adds the path for the `/.well-known/acme-challenge/` to the nginx configuration to map it to the path where the Let's Encrypt script generates the challenge files.

This fixes the 404 not found error when it's validating the challenge.
