### PR TITLE
Add arg to nginx listen proxy config to prevent Safari redirect issue

### DIFF
--- a/backend/src/AzuraRelay/Nginx.php
+++ b/backend/src/AzuraRelay/Nginx.php
@@ -53,6 +53,8 @@ final class Nginx
             proxy_connect_timeout     60;
 
             proxy_set_header Host localhost:{$port};
+
+            set \$args \$args&_ic2=1;
             proxy_pass http://127.0.0.1:{$port}/\$2?\$args;
         }
         NGINX;


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR adds the argument `&_ic2=1;` (like we do in AC itself) to the URL params of the proxied listen URL so that we can prevent the redirect that IC does for Safari listeners which breaks their streaming.
